### PR TITLE
Fixes translation issue of error messages

### DIFF
--- a/publicautocomplete.php
+++ b/publicautocomplete.php
@@ -125,7 +125,7 @@ function publicautocomplete_civicrm_buildForm($formName, &$form) {
   $vars = array(
     'return_properties' => $return_properties,
     'require_match' => _publicautocomplete_get_setting('require_match'),
-    'required_error' => ts('%1 must be an existing organization name.', array(1 => $form->_fields['current_employer']['title'])),
+    'required_error' => ts('%1 must be an existing organization name.', array(1 => $form->_fields['current_employer']['title'], 'domain' => ['eu.tttp.publicautocomplete', NULL])),
   );
   _publicautocomplete_setupJavascript($vars);
 }
@@ -146,7 +146,7 @@ function publicautocomplete_civicrm_validateForm($formName, &$fields, &$files, &
     // Only perform this validation if there's a value in the current_employer
     // field. If there is a value, and if it's not the exact name of an existing
     // valid employer, report an error.
-    $errors['current_employer'] = ts('%1 must be an existing organization name.', array(1 => $form->_fields['current_employer']['title']));
+    $errors['current_employer'] = ts('%1 must be an existing organization name.', array(1 => $form->_fields['current_employer']['title'], 'domain' => ['eu.tttp.publicautocomplete', NULL]));
   }
 }
 


### PR DESCRIPTION
**Before**
The message "%1 must be an existing organization name" was shown in English even though the civi site was in Dutch or French, and an .mo file is available.

**After**
The error message is properly translated.

**Comments**
Extensions made with a more recent version of civix use E::ts() instead of ts().
E::ts() adds the param 'domain' to the translation function, forcing it to look in the extension folder first.
In this fix 'domain' is added directly to the ts() call.

