### PR TITLE
suppresses autocomplete in modern browsers that ignore autocomplete=off

### DIFF
--- a/js/public.autocomplete-4.4.js
+++ b/js/public.autocomplete-4.4.js
@@ -90,6 +90,11 @@ cj(function($) {
     selectFirst: false
   });
 
+  // prevent autofill of the browser
+  // the tag contains the attribute autocomplete="off" but this is ignored by modern browsers
+  // autocomplete="new-password" works better
+  $('#current_employer').attr('autocomplete', 'new-password');
+
   // If we're configured to ensure that the current_employer field contains an
   // existing organization name, set that up now.
   if (CRM.vars['eu.tttp.publicautocomplete'].require_match === true) {

--- a/js/public.autocomplete-4.5.js
+++ b/js/public.autocomplete-4.5.js
@@ -79,6 +79,11 @@ cj(function($) {
     }
   });
 
+  // prevent autofill of the browser
+  // the tag contains the attribute autocomplete="off" but this is ignored by modern browsers
+  // autocomplete="new-password" works better
+  $('#current_employer').attr('autocomplete', 'new-password');
+
   // If we're configured to ensure that the current_employer field contains an
   // existing organization name, set that up now.
   if (CRM.vars['eu.tttp.publicautocomplete'].require_match === true) {


### PR DESCRIPTION
The HTML input tag "current_employer" contains the attribute autocomplete="off" to suppress autofill, but modern browsers ignore this.

So when autofill is turned on in the browser, the browser suggestion covers up the list generated by the extension. The user is then unable to select something from the list.

This PR changes the attribute to autocomplete="new-password", which is respected by modern browsers and effectively suppresses the autofill for the field current_employer.
