### PR TITLE
Allow user to specify additional forms in their civicrm.settings.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ global $civicrm_setting;
 $civicrm_setting['eu.tttp.publicautocomplete']['accept_existing_value'] = FALSE;
 ```
 
+### additional_forms
+If you want to add form class names for which to enable the autocomplete feature (beyond the built-in list), you can specify these as a string (single form name) or array (list of form names). Particularly useful if you have third-party extensions that create their own forms. For example:
+```php
+global $civicrm_setting;
+$civicrm_setting['eu.tttp.publicautocomplete']['additional_forms'] = 'CRM_Entity_Form_Type';
+```
+Or:
+```php
+global $civicrm_setting;
+$civicrm_setting['eu.tttp.publicautocomplete']['additional_forms'] = array(
+  'CRM_Entity1_Form_Type1',
+  'CRM_Entity2_Form_Type2',
+);
+```
+
 ### Anything else
 If you need something else or want to debug, you can modify the api/v3/Contact/Publicget.php and do whatever you want.
 

--- a/publicautocomplete.php
+++ b/publicautocomplete.php
@@ -18,15 +18,15 @@ function _publicautocomplete_supported_forms() {
 
   // Allow user to add their own forms to the above list
   // Could allow more advanced features e.g. wildcards / regex / match all or exclude forms
-  $additionalForms = _publicautocomplete_get_setting('additionalForms');
+  $additional_forms = _publicautocomplete_get_setting('additional_forms');
 
-  if (is_array($additionalForms))
+  if (is_array($additional_forms))
   {
-    $forms = array_merge($forms, $additionalForms);
+    $forms = array_merge($forms, $additional_forms);
   }
-  elseif (!empty($additionalForms))
+  elseif (!empty($additional_forms))
   {
-    $forms[] = $additionalForms;
+    $forms[] = $additional_forms;
   }
 
   return $forms;

--- a/publicautocomplete.php
+++ b/publicautocomplete.php
@@ -19,13 +19,10 @@ function _publicautocomplete_supported_forms() {
   // Allow user to add their own forms to the above list
   // Could allow more advanced features e.g. wildcards / regex / match all or exclude forms
   $additional_forms = _publicautocomplete_get_setting('additional_forms');
-
-  if (is_array($additional_forms))
-  {
+  if (is_array($additional_forms)) {
     $forms = array_merge($forms, $additional_forms);
   }
-  elseif (!empty($additional_forms))
-  {
+  elseif (!empty($additional_forms)) {
     $forms[] = $additional_forms;
   }
 

--- a/publicautocomplete.php
+++ b/publicautocomplete.php
@@ -8,15 +8,28 @@ use CRM_Publicautocomplete_ExtensionUtil as E;
  * Get an array of CiviCRM forms supported by this extension.
  */
 function _publicautocomplete_supported_forms() {
-  // FIXME: are there any forms where we /do not/ want this? Maybe change this
-  // to match for all forms.
-  return array(
+  $forms = array(
     'CRM_Profile_Form_Edit',
     'CRM_Event_Form_Registration_Register',
     'CRM_Contribute_Form_Contribution_Main',
     'CRM_Profile_Form_Dynamic',
     'CRM_Event_Form_Registration_AdditionalParticipant',
   );
+
+  // Allow user to add their own forms to the above list
+  // Could allow more advanced features e.g. wildcards / regex / match all or exclude forms
+  $additionalForms = _publicautocomplete_get_setting('additionalForms');
+
+  if (is_array($additionalForms))
+  {
+    $forms = array_merge($forms, $additionalForms);
+  }
+  elseif (!empty($additionalForms))
+  {
+    $forms[] = $additionalForms;
+  }
+
+  return $forms;
 }
 
 /**


### PR DESCRIPTION
This proposed change introduces a mechanism for users to specify their own additional form class names in their civicrm.settings.php file.

The use case that motivates this change is a third-party extension (in this case, Grant Application Forms) that creates its own form types that incorporate profiles, and may include an organisation / current_employer field.

Tested and working on CiviCRM 5.37.0.