### PR TITLE
Guard against passing empty $term to stristr()

### DIFF
--- a/api/v3/Contact/Getpublic.php
+++ b/api/v3/Contact/Getpublic.php
@@ -76,8 +76,9 @@ function civicrm_api3_contact_getpublic($params) {
       return $current_user_existing_employer_ret;
     }
     elseif (
-      (!empty($current_user_existing_employer_ret['values'][0]['current_employer'])) &&
-      (stristr($current_user_existing_employer_ret['values'][0]['current_employer'], $term) !== FALSE)
+      // Guard against passing empty $term to stristr() - can use empty() here because numeric input (i.e. zero) handled above
+      (!empty($current_user_existing_employer_ret['values'][0]['current_employer'])) && (!empty($term)) &&
+      (stristr($current_user_existing_employer_ret['values'][0]['current_employer'], (string) $term) !== FALSE)
     ) {
       $existing_employer_custom = array(
         'return' => $custom['return'],


### PR DESCRIPTION
Ensure that the `$needle` parameter to `stristr()` cannot be empty (causes warning) and also cast to string to make EXTRA SPECIALLY SURE that we are passing a string, otherwise will run into unexpected behaviour / errors in PHP 8 as described at https://www.php.net/manual/en/function.stristr.php.

Proposed fix to #43.

Tested and working on CiviCRM 5.50.4.