### PR TITLE
Fix for issue #45 (Public autocomplete not working on wordpress)

### DIFF
--- a/js/public.autocomplete-4.5.js
+++ b/js/public.autocomplete-4.5.js
@@ -75,7 +75,10 @@ cj(function($) {
         response([]);
       }
       else {
-          CRM.api3('contact', 'getpublic', {'term': term}).done(function(result) {
+        var oldIsFrontend = CRM.config.isFrontend;
+        CRM.config.isFrontend = true;
+        CRM.api3('contact', 'getpublic', {'term': term}).done(function(result) {
+          CRM.config.isFrontend = oldIsFrontend;
           // Initialize the list of autocomplete options.
           ret = [];
           if (result.count > 0) {
@@ -92,6 +95,8 @@ cj(function($) {
           }
           // Return the list of autocomplete options.
           response(ret);
+        }).fail(function() {
+          CRM.config.isFrontend = oldIsFrontend;
         });
       }
     }
@@ -122,7 +127,10 @@ cj(function($) {
     // so we can use it for validation in isValid().
     var initialValue = $('#current_employer').val();
     if (initialValue.length) {
+      var oldIsFrontend = CRM.config.isFrontend;
+      CRM.config.isFrontend = true;
       CRM.api3('contact', 'getpublic', {'term': initialValue}).done(function(result) {
+        CRM.config.isFrontend = oldIsFrontend;
         if (result.count > 0) {
           // Loop through the values returned by the AJAX call.
           $.each(result.values, function(k, v) {
@@ -130,6 +138,8 @@ cj(function($) {
             publicautocomplete.matchedValues[value] = true;
           });
         }
+      }).fail(function() {
+        CRM.config.isFrontend = oldIsFrontend;
       });
     }
   }


### PR DESCRIPTION
This is a fix for issue #45.

**Problem: technical description**

The autocomplete did not work in wordpress because the request made to retrieve autocomplete values was wrong.
That request was made to a CiviCRM backend URL. Causing wordpress to generate an access denied error.

The backend url is used because CiviCRM does not set the `CRM.config.isFrontend` correctly. (See this line: https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/Resources/Common.php#L150)

And I am not sure how this gets sets in wordpress.

**Fix**

So what this fix is setting is `CRM.config.isFrontend = true;` right before making an API call. This way the API call is using the frontend url.  
