### PR TITLE
Don't re-add core resources

### DIFF
--- a/publicautocomplete.php
+++ b/publicautocomplete.php
@@ -94,8 +94,7 @@ function _publicautocomplete_get_setting($name) {
  * Add given key-value pairs to CRM object in Javasript.
  */
 function _publicautocomplete_setupJavascript($vars) {
-  $resource = CRM_Core_Resources::singleton();
-  $resource->addCoreResources();
+  $resource = Civi::resources();
 
   // Fix bug on AJAX call to include js file
   CRM_Core_Region::instance('page-footer')->add([


### PR DESCRIPTION
This extension calls `CRM_Core_Resources::addCoreResources()`.  However, this is called already by CiviCRM and is only necessary to call explicitly when you're [on a non-CiviCRM page](https://docs.civicrm.org/dev/en/latest/standards/javascript/#using-civicrm-javascript-in-non-civicrm-pages).  This extension only works on CiviCRM pages, so this is unnecessary.

Its inclusion leads to a bug which took a long time to ferret out.  By re-adding core resources, it wipes `CRM_Core_Config->userFrameworkFrontend`, causing it to be recalculated incorrectly - and possibly only on WordPress.

To replicate this, create a contribution page with Stripe, add a "Current Employer" field, and grant the "Access AJAX API" permission.  Now try to submit the form.  Stripe throws an "Unknown error".

That's because Stripe calls its `ProcessPublic` API using the backend URL (`http://mysite.local/wp-admin/admin.php?page=CiviCRM&q=civicrm%2Fajax%2Fapi4%2FStripePaymentintent%2FProcessPublic`) instead of the front-end URL (`http://mysite.local/civicrm/ajax/api4/StripePaymentintent/ProcessPublic/`) because the `addCoreResources()` causes the `userFramrworkFrontend` value to be set to `FALSE`.

The change from `CRM_Core_Resources::singleton();` to `Civi::resources();` is cosmetic and I can remove it if need be.